### PR TITLE
docs: update README to reflect current state of 1st gen os2display project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> [!Important]
+> 
+> ### This project is no longer actively maintained.
+> 
+> The source code in this repository is no longer maintained. It has been superseded by [version 2](https://os2display.github.io/display-docs/), which offers improved features and better support.
+> 
+> Thank you to all who have contributed to this project. We recommend transitioning to [Os2Display version 2](https://os2display.github.io/display-docs/) for continued support and updates.
+> 
+> **Final Release**: The final stable release is version [1.1.7](https://github.com/os2display/screen-bundle/releases/tag/1.1.7)
+<br>
+
 # OS2Display screen-bundle
 
 Bundle to add a screen frontend to the administration.


### PR DESCRIPTION
@tuj Added an "Important note" similar to the PR to all the other `.*-bundle$` repos in the os2display org.
